### PR TITLE
fix: improve `maxLen` behavior

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,6 @@ jobs:
         run: pnpm vitest --coverage.enabled --coverage.all=false
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ Default: `false`
 
 If set `true`, always use explicit return when return value is `JSXElement` or `JSXFragment`.
 
+### `namedExportsAlwaysUseExplicitReturn`
+
+Type: `boolean`\
+Default: `true`
+
+By default, named exported arrow functions will always use explicit return to maintain consistency with regular functions because it is more intuitive and unified, and convenient for expansion.
+
 ## Rules
 
 <!-- prettier-ignore-start -->

--- a/src/rules/arrow-return-style.test.ts
+++ b/src/rules/arrow-return-style.test.ts
@@ -63,6 +63,24 @@ ruleTester.run(RULE_NAME, arrowReturnStyleRule, {
 
     {
       code: dedent`
+        const returnValues = blockBody
+          .filter((node): node is TSESTree.ReturnStatement => node.type === AST_NODE_TYPES.ReturnStatement)
+          .map((node) => node.argument)
+          .filter(Boolean);
+      `,
+
+      errors: [{ messageId: 'useExplicitReturn' }],
+
+      output: dedent`
+        const returnValues = blockBody
+          .filter((node): node is TSESTree.ReturnStatement => { return node.type === AST_NODE_TYPES.ReturnStatement })
+          .map((node) => node.argument)
+          .filter(Boolean);
+      `,
+    },
+
+    {
+      code: dedent`
         const delay = () =>
           new Promise((resolve) => {
             setTimeout(resolve, 1000)

--- a/src/rules/arrow-return-style.test.ts
+++ b/src/rules/arrow-return-style.test.ts
@@ -19,6 +19,50 @@ ruleTester.run(RULE_NAME, arrowReturnStyleRule, {
   invalid: [
     {
       code: dedent`
+        const UDimTemporary = (value: UDim, rem: number): UDim => new UDim(value.Scale, value.Offset * rem);
+      `,
+
+      errors: [{ messageId: 'useExplicitReturn' }],
+
+      output: dedent`
+        const UDimTemporary = (value: UDim, rem: number): UDim => { return new UDim(value.Scale, value.Offset * rem) };
+      `,
+    },
+
+    {
+      code: dedent`
+        const obj = {
+          UDimTemporary11111111111: (value: UDim, rem: number): UDim =>
+            new UDim(value.Scale, value.Offset * rem),
+        };
+      `,
+
+      errors: [{ messageId: 'useExplicitReturn' }],
+
+      output: dedent`
+        const obj = {
+          UDimTemporary11111111111: (value: UDim, rem: number): UDim =>
+            { return new UDim(value.Scale, value.Offset * rem) },
+        };
+      `,
+    },
+
+    {
+      code: dedent`
+        const isVariableDeclaration = (node: TSESTree.Node | null | undefined): node is TSESTree.VariableDeclaration =>
+          node?.type === AST_NODE_TYPES.VariableDeclaration;
+      `,
+
+      errors: [{ messageId: 'useExplicitReturn' }],
+
+      output: dedent`
+        const isVariableDeclaration = (node: TSESTree.Node | null | undefined): node is TSESTree.VariableDeclaration =>
+          { return node?.type === AST_NODE_TYPES.VariableDeclaration };
+      `,
+    },
+
+    {
+      code: dedent`
         const delay = () =>
           new Promise((resolve) => {
             setTimeout(resolve, 1000)
@@ -236,5 +280,27 @@ ruleTester.run(RULE_NAME, arrowReturnStyleRule, {
       code: "export const getUser = async () => ({ name: 'admin' })",
       options: [{ namedExportsAlwaysUseExplicitReturn: false }],
     },
+
+    dedent`
+      const isMaxLen = (node = arrowRoot) => {
+        return node.loc.end.column - node.loc.start.column >= maxLen;
+      };
+    `,
+
+    dedent`
+      const isVariableDeclaration = (
+        node: TSESTree.Node | null | undefined,
+      ): node is TSESTree.VariableDeclaration => {
+        return node?.type === AST_NODE_TYPES.VariableDeclaration;
+      };
+    `,
+
+    dedent`
+      const obj = {
+        temporary: (v: UDim, rem = 0) => {
+          return new UDim(v.Scale, v.Offset * rem);
+        },
+      };
+    `,
   ],
 });

--- a/src/rules/arrow-return-style.test.ts
+++ b/src/rules/arrow-return-style.test.ts
@@ -315,9 +315,7 @@ ruleTester.run(RULE_NAME, arrowReturnStyleRule, {
 
     dedent`
       const obj = {
-        temporary: (v: UDim, rem = 0) => {
-          return new UDim(v.Scale, v.Offset * rem);
-        },
+        temporary: (v: UDim, rem = 0) => new UDim(v.Scale, v.Offset * rem),
       };
     `,
   ],

--- a/src/rules/arrow-return-style.ts
+++ b/src/rules/arrow-return-style.ts
@@ -27,9 +27,7 @@ export const arrowReturnStyleRule = createRule<Options, MessageIds>({
           namedExportsAlwaysUseExplicitReturn = true,
         } = context.options?.[0] || {};
 
-        const isMaxLen = (node: TSESTree.Node = getArrowRoot()) => {
-          return getTokensLength(node) > maxLen;
-        };
+        const isMaxLen = (node: TSESTree.Node = getArrowRoot()) => getTokensLength(node) > maxLen;
 
         const isMultiline = (node: TSESTree.NodeOrTokenData = arrowBody) => {
           return node.loc.start.line !== node.loc.end.line;

--- a/src/rules/arrow-return-style.ts
+++ b/src/rules/arrow-return-style.ts
@@ -41,7 +41,7 @@ export const arrowReturnStyleRule = createRule<Options, MessageIds>({
 
         const isMaxLen = (node = arrowRoot) => node.range[1] - node.range[0] > maxLen;
 
-        const isMultiline = (node = arrowRoot) => {
+        const isMultiline = (node = arrowBody) => {
           return node.loc.start.line !== node.loc.end.line;
         };
 

--- a/src/rules/no-export-default-arrow.ts
+++ b/src/rules/no-export-default-arrow.ts
@@ -23,7 +23,9 @@ export const noExportDefaultArrowRule = createRule({
             const blockBody = arrowBody.body;
 
             const returnValues = blockBody
-              .filter((node): node is TSESTree.ReturnStatement => node.type === AST_NODE_TYPES.ReturnStatement)
+              .filter((node): node is TSESTree.ReturnStatement => {
+                return node.type === AST_NODE_TYPES.ReturnStatement;
+              })
               .map((node) => node.argument)
               .filter(Boolean);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option `namedExportsAlwaysUseExplicitReturn` to enforce explicit return in named exported arrow functions for consistency.
- **Chores**
	- Updated `codecov-action` in the CI workflow to version `v4` for improved coverage reporting.
- **Style**
	- Enforced explicit return statements in arrow functions across various files to enhance code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->